### PR TITLE
Fixed crash

### DIFF
--- a/toolchain/prizm.x
+++ b/toolchain/prizm.x
@@ -1,4 +1,4 @@
-/*OUTPUT_FORMAT(binary)*/
+OUTPUT_FORMAT(binary)
 OUTPUT_ARCH(sh3)
  
 /* Entry point.  Not really important here, since doing binary output */
@@ -9,7 +9,7 @@ MEMORY
         /* Loads code at 300000, skips g3a header */
         rom (rx) : o = 0x00300000, l = 1024k
         ram (rwx) : o = 0x08100004, l = 64k  /* pretty safe guess */
-        ilram (rwx) : o = 0xE5200000, l = 16k
+        ilram (rwx) : o = 0xE5200000, l = 4k /* According to http://www.cemetech.net/forum/viewtopic.php?t=9334 */
 }
  
 SECTIONS


### PR DESCRIPTION
Trying to build examples/make-libfxcg with OUTPUT_FORMAT(binary) commented crashes the Casio Prizm by uncommenting the line it fixed the crash and now the program will run.
