### PR TITLE
Restore memset and fix memmove

### DIFF
--- a/libc/string.c
+++ b/libc/string.c
@@ -50,13 +50,58 @@ void* memcpy(void* destination, const void* source, size_t num) {
 }
 */
 
-// TODO extremely inefficient and generally bad.
-void* memmove(void* destination, const void* source, size_t num) {
-	void* d = malloc(num);
-	memcpy(d, source, num);
-	memcpy(destination, d, num);
-	free(d);
-	return destination;
+void*memmove(void*dst,const void*src,size_t n){
+	if(src>dst){
+		unsigned char*d8=(unsigned char*)dst;
+		const unsigned char*s8=(unsigned char*)src;
+		unsigned*d=(unsigned*)d8;
+		const unsigned*s=(unsigned*)s8;
+		while((unsigned)s8&3){
+			*d8++=*s8++;/*It is done like this due to SH's move instruction then postincrement address*/
+			--n;
+		}
+		d=(unsigned*)d8;
+		s=(unsigned*)s8;
+		while(n>=4){
+			*d++=*s++;
+			n-=4;
+		}
+		if(n){
+			d8=(unsigned char*)d;
+			s8=(unsigned char*)s;
+			while(n--)
+				*d8++=*s8++;
+		}
+	}else if(src<dst){
+		unsigned char*d8=(unsigned char*)dst+n;
+		const unsigned char*s8=(unsigned char*)src+n;
+		unsigned*d=(unsigned*)d8;
+		const unsigned*s=(unsigned*)s8;
+		while((unsigned)s8&3){
+			*(--d8)=*(--s8);/*It is done like this due to SH's preincrement address then move instruction*/
+			--n;
+		}
+		d=(unsigned*)d8;
+		s=(unsigned*)s8;
+		while(n>=4){
+			*(--d)=*(--s);
+			n-=4;
+		}
+		if(n){
+			d8=(unsigned char*)d;
+			s8=(unsigned char*)s;
+			while(n--)
+				*(--d8)=*(--s8);
+		}
+	}
+	return dst;
+}
+
+void *memset(void *dest, int c, unsigned int n) {
+	char* d = (char*)dest;
+	while (n-- > 0) { *d++ = (char)c; }
+	
+	return dest;
 }
 
 char *strcat(char *dest, const char *src) {


### PR DESCRIPTION
Your revert memmove my implementation commit also removed memset so I added the old code back in. As for memmove, this commit fixes the comparisons and also removes all compiler warnings for memmove.
