### PR TITLE
Revert "Restore memset and fix memmove"

### DIFF
--- a/libc/string.c
+++ b/libc/string.c
@@ -59,6 +59,13 @@ void* memmove(void* destination, const void* source, size_t num) {
 	return destination;
 }
 
+void *memset(void *dest, int c, unsigned int n) {
+    char* d = (char*)dest;
+    while (n-- > 0) { *d++ = (char)c; }
+
+    return dest;
+}
+
 char *strcat(char *dest, const char *src) {
 	char* ret = dest;
 	dest += strlen(dest);


### PR DESCRIPTION
Reverts Jonimoose/libfxcg#25

```
[22:46:47] < gbl08ma> The bad news is, ProgrammerNerd's memmove or something else keeps being broken.
[22:47:03] < gbl08ma> another system error, but this time with a PC of 0x04.
[22:47:36] < gbl08ma> this code works fine with the lazy memmove, and it wasn't written by myself but by a skilled
                      programmer, so I'm sure the problem is with memmove.
```
