### PR TITLE
A memmove that works.

### DIFF
--- a/libc/string.c
+++ b/libc/string.c
@@ -50,13 +50,19 @@ void* memcpy(void* destination, const void* source, size_t num) {
 }
 */
 
-// TODO extremely inefficient and generally bad.
-void* memmove(void* destination, const void* source, size_t num) {
-	void* d = malloc(num);
-	memcpy(d, source, num);
-	memcpy(destination, d, num);
-	free(d);
-	return destination;
+void*memmove(void*dst,const void*src,size_t n){
+	if(src>dst){
+		unsigned char*d8=(unsigned char*)dst;
+		const unsigned char*s8=(unsigned char*)src;
+		while(n--)
+			*d8++=*s8++;
+	}else if(src<dst){
+		unsigned char*d8=(unsigned char*)dst+n;
+		const unsigned char*s8=(unsigned char*)src+n;
+		while(n--)
+			*(--d8)=*(--s8);
+	}
+	return dst;
 }
 
 void *memset(void *dest, int c, unsigned int n) {


### PR DESCRIPTION
First of all I would like to apologize for the time that my previous memmove implementation wasted. Yes I should have done more testing but I really wanted that old version of memmove gone as soon as possible.
I took a quick look a gbl08ma's code and it was likely that small values were passed to memmove. The bug in my previous implementation is that in the loop that aligns the source pointer before doing the 4 byte copy did not check the value of n and it caused an overflow. When source was aligned finally, from the perspective of the algorithm there were around 4 billion bytes to copy.This code that I propose is very simple as you can tell and does not contain the flaw that my previous implementation did.. I decided to not use the align and copy algorithm as it does not solve the issue that dst is still unaligned if they have a different &3 value. Anyways I will be very surprised if this code fails. 
