### PR TITLE
Disabled exceptions for C++ builds

### DIFF
--- a/examples/skeleton/Makefile
+++ b/examples/skeleton/Makefile
@@ -32,7 +32,7 @@ INCLUDES	:=
 MKG3AFLAGS := -n basic:example -i uns:../unselected.bmp -i sel:../selected.bmp
 
 CFLAGS	= -Os -Wall $(MACHDEP) $(INCLUDE) -ffunction-sections -fdata-sections 
-CXXFLAGS	=	$(CFLAGS)
+CXXFLAGS	=	$(CFLAGS) -fno-exceptions
 
 LDFLAGS	= $(MACHDEP) -T$(FXCGSDK)/toolchain/prizm.x -Wl,-static -Wl,-gc-sections
 


### PR DESCRIPTION
Reasoning detailed in https://github.com/Jonimoose/libfxcg/issues/50.

https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_exceptions.html

Enabling -fno-exceptions for C++ builds explicitly disables exceptions (which would be very complicated to implement). The result of this is that things like operator new become much easier to implement and the compiler will give a more useful error whenever someone tries to use throw, try and catch. It also significantly reduces the sizes of the produced binaries and G3A files.