### PR TITLE
Correct partial use of LTO in libraries

### DIFF
--- a/examples/skeleton/Makefile
+++ b/examples/skeleton/Makefile
@@ -31,7 +31,11 @@ INCLUDES	:=
 
 MKG3AFLAGS := -n basic:example -i uns:../unselected.bmp -i sel:../selected.bmp
 
-CFLAGS	= -Os -Wall $(MACHDEP) $(INCLUDE) -ffunction-sections -fdata-sections 
+# Optional: add -flto to CFLAGS and LDFLAGS to enable link-time optimization
+# (LTO). Doing so will usually allow the compiler to generate much better code
+# (smaller and/or faster), but may expose bugs in your code that don't cause
+# any trouble without LTO enabled.
+CFLAGS	= -Os -Wall $(MACHDEP) $(INCLUDE) -ffunction-sections -fdata-sections
 CXXFLAGS	=	$(CFLAGS) -fno-exceptions
 
 LDFLAGS	= $(MACHDEP) -T$(FXCGSDK)/toolchain/prizm.x -Wl,-static -Wl,-gc-sections

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,8 +1,8 @@
 TOOLCHAIN_PREFIX=sh3eb-elf-
 CC=$(TOOLCHAIN_PREFIX)gcc
 AS=$(TOOLCHAIN_PREFIX)as
-AR=$(TOOLCHAIN_PREFIX)ar
-CFLAGS=-c -ffunction-sections -fdata-sections -Os \
+AR=$(TOOLCHAIN_PREFIX)gcc-ar
+CFLAGS=-c -ffunction-sections -fdata-sections -Os -flto -ffat-lto-objects \
 	   -m4a-nofpu -mhitachi -ffreestanding -Wall -Wsystem-headers -g -I../include
 LDFLAGS=-Wl,-static -lfxcg
 ARFLAGS=rsv

--- a/libfxcg/Makefile
+++ b/libfxcg/Makefile
@@ -1,9 +1,9 @@
 TOOLCHAIN_PREFIX=sh3eb-elf-
 CC=$(TOOLCHAIN_PREFIX)gcc
 AS=$(TOOLCHAIN_PREFIX)as
-AR=$(TOOLCHAIN_PREFIX)ar
+AR=$(TOOLCHAIN_PREFIX)gcc-ar
 CFLAGS=-c -ffunction-sections -fdata-sections -Os -Lr -I../include \
-	   -mhitachi -m4a-nofpu -flto -std=c99 -Wall -Wextra
+	   -mhitachi -m4a-nofpu -flto -ffat-lto-objects -std=c99 -Wall -Wextra
 ARFLAGS=rs
 VPATH=syscalls
 SHSOURCES=$(wildcard syscalls/*.S) $(wildcard misc/*.S)

--- a/toolchain/prizm_rules
+++ b/toolchain/prizm_rules
@@ -20,7 +20,7 @@ PREFIX	:=	sh3eb-elf-
 export AS	:=	$(PREFIX)as
 export CC	:=	$(PREFIX)gcc
 export CXX	:=	$(PREFIX)g++
-export AR	:=	$(PREFIX)ar
+export AR	:=	$(PREFIX)gcc-ar
 export OBJCOPY	:=	$(PREFIX)objcopy
 export MKG3A := mkg3a
 


### PR DESCRIPTION
We've been building libfxcg with LTO, which will fail to link correctly
when users aren't also using LTO. To allow non-LTO link to succeed,
enable fat objects (that contain both IR and object code) when building
libraries. Also enable LTO for the libc build, since it wasn't enabled.

Also use gcc-ar rather than plain ar, to ensure the archiver also knows
about LTO objects in whatever way it may need to.

Finally, add some notes to the example Makefile describing how and why
a user may wish to enable LTO.

Should fix #53.