### PR TITLE
Correct example library link order

### DIFF
--- a/examples/skeleton/Makefile
+++ b/examples/skeleton/Makefile
@@ -39,7 +39,7 @@ LDFLAGS	= $(MACHDEP) -T$(FXCGSDK)/toolchain/prizm.x -Wl,-static -Wl,-gc-sections
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	 -lfxcg -lc -lgcc
+LIBS	:=	 -lc -lfxcg -lgcc
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/include/fxcg.h
+++ b/include/fxcg.h
@@ -51,7 +51,6 @@ char *sys_strncpy(char *dest, const char *src, size_t n);
 #define memcpy sys_memcpy
 #define memset sys_memset
 #define memmove sys_memmove
-#define strlen sys_strlen
 #define strcpy sys_strcpy
 #define strncpy sys_strncpy
 #define strchr sys_strchr


### PR DESCRIPTION
As libc should be able to depend on libfxcg, we should make suggested link order put libc first because the linker only records needed symbols so dependencies should come after their dependents on the command line.

Should address link-time errors reported at https://www.cemetech.net/forum/viewtopic.php?p=292622