### PR TITLE
Remove duplicate memset function to fix undefined reference to `memset' errors.

### DIFF
--- a/libc/string.c
+++ b/libc/string.c
@@ -50,13 +50,6 @@ void*memmove(void*dst,const void*src,size_t n){
     return dst;
 }
 
-void *memset(void *dest, int c, unsigned int n) {
-    char* d = (char*)dest;
-    while (n-- > 0) { *d++ = (char)c; }
-
-    return dest;
-}
-
 char *strcat(char *dest, const char *src) {
     char* ret = dest;
     dest += strlen(dest);


### PR DESCRIPTION
I tried to compile some code which used memset but whenever I would try and build it I would get an error that said:
undefined reference to `memset'.

It turns out that it was defined twice. Once in libfxcg and once in libc. I decided to keep the assembly version because it looked like it had some optimizations but I have not benchmarked the two implementations or tested them much.

After making this change the error went away.