### PR TITLE
Fix the definitions for functions that take no arguments but were marked as variable argument functions.

### DIFF
--- a/include/fxcg.h
+++ b/include/fxcg.h
@@ -14,7 +14,7 @@ extern "C" {
 #include "fxcg_syscalls.h"
 #include "fxcg_registers.h"
 
-int PRGM_GetKey();
+int PRGM_GetKey(void);
 
 void VRAM_CopySprite(const color_t* data, int x, int y, int width, int height);
 void VRAM_XORSprite(const color_t* data, int x, int y, int width, int height);

--- a/include/fxcg/app.h
+++ b/include/fxcg/app.h
@@ -14,8 +14,8 @@ void APP_SYSTEM_RESET( void );
 void APP_SYSTEM_VERSION( void );
 void APP_SYSTEM( void );
 void APP_RUNMAT(int, int);
-void APP_MEMORY();
-void App_Optimize();
+void APP_MEMORY(void);
+void App_Optimize(void);
 
 void ResetAllDialog( void );
 unsigned char*GetAppName( unsigned char*name );

--- a/include/fxcg/keyboard.h
+++ b/include/fxcg/keyboard.h
@@ -205,7 +205,7 @@ void Set_FKeys1( unsigned int p1, unsigned int*P2 );
 void PRGM_GetKey_OS( unsigned char*p );
 int GetKey(int*key);
 int GetKeyWait_OS(int*column, int*row, int type_of_waiting, int timeout_period, int menu, unsigned short*keycode );
-int PRGM_GetKey();
+int PRGM_GetKey(void);
 void DisplayMBString(unsigned char *MB_string, int start, int xpos, int x, int y);
 void DisplayMBString2( int P1, unsigned char*MB_string, int start, int xpos, int x, int y, int pos_to_clear, int P8, int P9 );
 void EditMBStringCtrl(unsigned char *MB_string, int posmax, int *start, int *xpos, int *key, int x, int y);

--- a/include/fxcg/system.h
+++ b/include/fxcg/system.h
@@ -5,17 +5,17 @@ extern "C" {
 // This adds in syscalls for interfacing with the OS and hardware.
 
 void SetAutoPowerOffTime(int durationInMinutes);
-int GetAutoPowerOffTime(); //returns duration in minutes
+int GetAutoPowerOffTime(void); //returns duration in minutes
 
 void SetBacklightDuration(char durationInHalfMinutes);
-char GetBacklightDuration(); //returns duration in half-minutes
+char GetBacklightDuration(void); //returns duration in half-minutes
 
 void SetBatteryType(int type);
 int GetBatteryType(void);
 
 int GetMainBatteryVoltage(int one); //parameter should be 1
 void PowerOff(int displayLogo);
-void Restart();
+void Restart(void);
 void SpecialMatrixcodeProcessing(int*col, int*row);
 void TestMode(int);
 void*GetStackPtr(void);

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -29,7 +29,7 @@ double strtod(const char *s, char **str_end);
 void qsort(void *base, size_t nel, size_t width, int (*compar)(const void *, const void *));
 
 void exit(int status) __attribute__ ((noreturn));
-void abort();
+void abort(void);
 
 #ifdef __cplusplus
 }

--- a/libc/stdlib.c
+++ b/libc/stdlib.c
@@ -53,7 +53,7 @@ void exit(int status) {
         GetKey(&key);
 }
 
-void abort() {
+void abort(void) {
     fprintf(stderr, "ABORT CALLED\nPress menu key to exit\n");
 #ifndef STDERR_TO_VRAM
     /* Initialize the status area so that it can display text


### PR DESCRIPTION
This isn't an issue in C++ code but in C () means variable arguments. Using (void) works for both C and C++.