### PR TITLE
examples/starfield: don't hard-code VRAM address

### DIFF
--- a/.github/workflows/windows-sdk.yml
+++ b/.github/workflows/windows-sdk.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build Windows toolchain
     runs-on: ubuntu-latest
     container:
-      image: jonimoose/libfxcg-toolchain
+      image: ghcr.io/tari/libfxcg:toolchain
     steps:
       - name: Install packages
         run: |

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -1,7 +1,7 @@
 FROM scratch
 MAINTAINER Peter Marheine <peter@taricorp.net>
 
-FROM debian:buster-slim AS prereqs
+FROM debian:bullseye-slim AS prereqs
 RUN apt-get -qq update
 RUN apt-get -y install build-essential libmpfr-dev libmpc-dev libgmp-dev libpng-dev ppl-dev curl git cmake texinfo
 
@@ -31,6 +31,6 @@ RUN make install-gcc
 RUN make -j$(nproc) inhibit_libc=true all-target-libgcc
 RUN make install-target-libgcc
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 COPY --from=gcc /usr/local /usr/local
 RUN apt-get -qq update && apt-get -qqy install make libmpc3 && apt-get -qqy clean

--- a/examples/display/starfield/main.c
+++ b/examples/display/starfield/main.c
@@ -44,7 +44,7 @@ void main(void){
     memset(screeny,0,64*sizeof(int));
     memset(screenxold,0,64*sizeof(int));
     memset(screenyold,0,64*sizeof(int));
-    memset((short*)0xA8000000,0,384*216*2);
+    memset(GetVRAMAddress(),0,384*216*2);
     unsigned seed=RTC_GetTicks(),i;
     for(i=0;i<STARSAMT;++i)
         seed=newStar(starx+i,stary+i,starz+i,starzv+i,seed);
@@ -84,12 +84,12 @@ void main(void){
     }
 }
 static void DrawPixelGray(int x,int y,int col){
-    unsigned short*v=(unsigned short*)0xA8000000;
+    unsigned short*v= GetVRAMAddress();
     v+=y*384+x;
     *v=col*2113;//Convert from gray 0-31 to rgb565
 }
 static void DrawPixelSet(int x,int y,unsigned short col){
-    unsigned short*v=(unsigned short*)0xA8000000;
+    unsigned short*v= GetVRAMAddress();
     v+=y*384+x;
     *v=col;
 }


### PR DESCRIPTION
Hard-coding it is not compatible with CG50 calculators.

Fixes #66.