### PR TITLE
Add 'clean' to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,11 @@ lib/libc.a: lib libc/libc.a
 
 libc/libc.a:
 	make -C libc
+
+clean:
+	rm lib/*.a
+	rm libc/*.o
+	rm libc/*.a
+	rm libfxcg/*.a
+	rm libfxcg/misc/*.o
+	rm libfxcg/syscalls/*.o


### PR DESCRIPTION
Hello,
I have added a `clean` target to the Makefile so that built archives and objects can be removed.
This is useful whenever you recompile libfxcg.