### PR TITLE
Remove unusable math prototypes

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -25,9 +25,6 @@ extern "C" {
 #define M_SQRT2 1.41421356237309504880    /* sqrt(2) */
 #define M_SQRT1_2 0.70710678118654752440  /* 1/sqrt(2) */
 
-double fabs(double x);
-long labs(long n);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/math.h
+++ b/include/math.h
@@ -11,34 +11,22 @@ extern "C" {
 #define HUGE_VALF __builtin_huge_valf()
 #define HUGE_VALL __builtin_huge_vall()
 
-#define M_E             2.7182818284590452354   /* e */
-#define M_LOG2E         1.4426950408889634074   /* log_2 e */
-#define M_LOG10E        0.43429448190325182765  /* log_10 e */
-#define M_LN2           0.69314718055994530942  /* log_e 2 */
-#define M_LN10          2.30258509299404568402  /* log_e 10 */
-#define M_PI            3.14159265358979323846  /* pi */
-#define M_PI_2          1.57079632679489661923  /* pi/2 */
-#define M_PI_4          0.78539816339744830962  /* pi/4 */
-#define M_1_PI          0.31830988618379067154  /* 1/pi */
-#define M_2_PI          0.63661977236758134308  /* 2/pi */
-#define M_2_SQRTPI      1.12837916709551257390  /* 2/sqrt(pi) */
-#define M_SQRT2         1.41421356237309504880  /* sqrt(2) */
-#define M_SQRT1_2       0.70710678118654752440  /* 1/sqrt(2) */
+#define M_E 2.7182818284590452354         /* e */
+#define M_LOG2E 1.4426950408889634074     /* log_2 e */
+#define M_LOG10E 0.43429448190325182765   /* log_10 e */
+#define M_LN2 0.69314718055994530942      /* log_e 2 */
+#define M_LN10 2.30258509299404568402     /* log_e 10 */
+#define M_PI 3.14159265358979323846       /* pi */
+#define M_PI_2 1.57079632679489661923     /* pi/2 */
+#define M_PI_4 0.78539816339744830962     /* pi/4 */
+#define M_1_PI 0.31830988618379067154     /* 1/pi */
+#define M_2_PI 0.63661977236758134308     /* 2/pi */
+#define M_2_SQRTPI 1.12837916709551257390 /* 2/sqrt(pi) */
+#define M_SQRT2 1.41421356237309504880    /* sqrt(2) */
+#define M_SQRT1_2 0.70710678118654752440  /* 1/sqrt(2) */
 
-
-double atan2(double y, double x);
-double cos(double x);
-double exp(double x);
 double fabs(double x);
-double floor(double arg);
-double fmod(double x, double y);
-double frexp(double arg, int *exp);
 long labs(long n);
-double ldexp(double arg, int exp);
-double log(double x);
-double modf(double x, double *iptr);
-double pow(double x, double y);
-double sin(double x);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hello!

I have removed all the unusable math prototypes from math.h because of issue #54.

Through testing, I found that labs and fabs work, so I'm not sure if this is GCC magic or it has actually been implemented somewhere - so I left them in.