### PR TITLE
Add Bdisp_Rectangle, FilledRectangle, Filled 16C

### DIFF
--- a/include/fxcg/display.h
+++ b/include/fxcg/display.h
@@ -88,13 +88,13 @@ void Bdisp_ShapeBase( unsigned char*work, struct display_shape *shape, int color
 void Bdisp_ShapeToVRAM16C( void*, int color );
 void Bdisp_ShapeToDD( void*shape, int color );
 
-// Rectangle drawing, x between 0 and 383 (inclusive), y between 0 and 191 (inclusive).
+// Draws rectangle to VRAM, x between 0 and 383 (inclusive), y between 0 and 191 (inclusive).
 // These avoid the status bar:
-// Direct Draws a rectangle using a TEXT_COLOR.
+// Draws a rectangle to VRAM using a TEXT_COLOR.
 void Bdisp_Rectangle( int x1, int y1, int x2, int y2, char color );
-// Direct Draws a filled rectangle using a TEXT_COLOR
+// Draws a filled rectangle to VRAM using a TEXT_COLOR
 void Bdisp_FilledRectangle( int x1, int y1, int x2, int y2, char color );
-// Direct Draws a filled rectangle using a color_t
+// Draws a filled rectangle to VRAM using a color_t
 void Bdisp_FilledRectangleFullColor( int x1, int y1, int x2, int y2, unsigned short color );
 
 //Background-related syscalls

--- a/include/fxcg/display.h
+++ b/include/fxcg/display.h
@@ -88,14 +88,16 @@ void Bdisp_ShapeBase( unsigned char*work, struct display_shape *shape, int color
 void Bdisp_ShapeToVRAM16C( void*, int color );
 void Bdisp_ShapeToDD( void*shape, int color );
 
-// Draws rectangle to VRAM, x between 0 and 383 (inclusive), y between 0 and 191 (inclusive).
-// These avoid the status bar:
+// The following rectangle-related syscalls draw a rectangle to VRAM, x between 0 and 383 (inclusive), y between 0 and 191 (inclusive).
+// These add 24 pixels automatically, avoiding the status area:
+
 // Draws a rectangle to VRAM using a TEXT_COLOR.
 void Bdisp_Rectangle( int x1, int y1, int x2, int y2, char color );
 // Draws a filled rectangle to VRAM using a TEXT_COLOR
 void Bdisp_FilledRectangle( int x1, int y1, int x2, int y2, char color );
 // Draws a filled rectangle to VRAM using a color_t
 void Bdisp_FilledRectangleFullColor( int x1, int y1, int x2, int y2, unsigned short color );
+
 
 //Background-related syscalls
 void SetBackGround( int );

--- a/include/fxcg/display.h
+++ b/include/fxcg/display.h
@@ -88,8 +88,13 @@ void Bdisp_ShapeBase( unsigned char*work, struct display_shape *shape, int color
 void Bdisp_ShapeToVRAM16C( void*, int color );
 void Bdisp_ShapeToDD( void*shape, int color );
 
+// Rectangle drawing, x between 0 and 383 (inclusive), y between 0 and 191 (inclusive).
+// These avoid the status bar:
+// Direct Draws a rectangle using a TEXT_COLOR.
 void Bdisp_Rectangle( int x1, int y1, int x2, int y2, char color );
+// Direct Draws a filled rectangle using a TEXT_COLOR
 void Bdisp_FilledRectangle( int x1, int y1, int x2, int y2, char color );
+// Direct Draws a filled rectangle using a color_t
 void Bdisp_FilledRectangleFullColor( int x1, int y1, int x2, int y2, unsigned short color );
 
 //Background-related syscalls

--- a/include/fxcg/display.h
+++ b/include/fxcg/display.h
@@ -87,6 +87,11 @@ void Bdisp_ShapeBase3XVRAM( void*shape );
 void Bdisp_ShapeBase( unsigned char*work, struct display_shape *shape, int color, int line_width, int zero1, int zero2 );
 void Bdisp_ShapeToVRAM16C( void*, int color );
 void Bdisp_ShapeToDD( void*shape, int color );
+
+void Bdisp_Rectangle( int x1, int y1, int x2, int y2, char color );
+void Bdisp_FilledRectangle( int x1, int y1, int x2, int y2, char color );
+void Bdisp_FilledRectangle16C( int x1, int y1, int x2, int y2, unsigned short color );
+
 //Background-related syscalls
 void SetBackGround( int );
 void WriteBackground( void*target, int width, int height, void*source, int, int, int );

--- a/include/fxcg/display.h
+++ b/include/fxcg/display.h
@@ -90,7 +90,7 @@ void Bdisp_ShapeToDD( void*shape, int color );
 
 void Bdisp_Rectangle( int x1, int y1, int x2, int y2, char color );
 void Bdisp_FilledRectangle( int x1, int y1, int x2, int y2, char color );
-void Bdisp_FilledRectangle16C( int x1, int y1, int x2, int y2, unsigned short color );
+void Bdisp_FilledRectangleFullColor( int x1, int y1, int x2, int y2, unsigned short color );
 
 //Background-related syscalls
 void SetBackGround( int );

--- a/libfxcg/syscalls/Bdisp_FilledRectangle.S
+++ b/libfxcg/syscalls/Bdisp_FilledRectangle.S
@@ -1,0 +1,3 @@
+#include <asm.h>
+
+SYSCALL(_Bdisp_FilledRectangle, 0x0925)

--- a/libfxcg/syscalls/Bdisp_FilledRectangle16C.S
+++ b/libfxcg/syscalls/Bdisp_FilledRectangle16C.S
@@ -1,0 +1,3 @@
+#include <asm.h>
+
+SYSCALL(_Bdisp_FilledRectangle16C, 0x0926)

--- a/libfxcg/syscalls/Bdisp_FilledRectangle16C.S
+++ b/libfxcg/syscalls/Bdisp_FilledRectangle16C.S
@@ -1,3 +1,0 @@
-#include <asm.h>
-
-SYSCALL(_Bdisp_FilledRectangle16C, 0x0926)

--- a/libfxcg/syscalls/Bdisp_FilledRectangleFullColor.S
+++ b/libfxcg/syscalls/Bdisp_FilledRectangleFullColor.S
@@ -1,0 +1,3 @@
+#include <asm.h>
+
+SYSCALL(_Bdisp_FilledRectangleFullColor, 0x0926)

--- a/libfxcg/syscalls/Bdisp_Rectangle.S
+++ b/libfxcg/syscalls/Bdisp_Rectangle.S
@@ -1,0 +1,3 @@
+#include <asm.h>
+
+SYSCALL(_Bdisp_Rectangle, 0x0924)


### PR DESCRIPTION
Hello!

In this PR, I have added 3 syscalls from [Simon Lothar's document](https://bible.planet-casio.com/simlo/chm/v20/fxCG20_display.htm).

These include:
Bdisp_Rectangle
* Draws a rectangle with a char colour (one of the 8).
Bdisp_FilledRectangle
* Draws a filled rectangle with a char colour.
Bdisp_FilledRectangle16C
* Draws a filled rectangle with an unsigned short (colour_t).

0x24 is automatically added to the y-values, so it avoids the status bar.
x1 and x2 are between 0 and 383 (inclusive),
y1 and y2 are between 0 and 191 (inclusive).

These all draw to VRAM, so Bdisp_PutDisp_DD() (or GetKey(), or anything else that calls this) is required.

Obviously, the names are subject to change - feel free to use better ones.