### PR TITLE
Add alias to sys_calloc and fix sys_calloc

### DIFF
--- a/libc/stdlib.c
+++ b/libc/stdlib.c
@@ -13,6 +13,7 @@ int errno;
 __attribute__((weak)) void free(void *p) { sys_free(p); }
 __attribute__((weak)) void *malloc(size_t sz) { return sys_malloc(sz); }
 __attribute__((weak)) void *realloc(void *p, size_t sz) { return sys_realloc(p, sz); }
+__attribute__((weak)) void *calloc(int elements, int elementsize) { return sys_calloc(elements, elementsize); }
 
 void exit(int status) {
     /* TODO: if necessary, perform cleanup here, and call functions

--- a/libfxcg/misc/calloc.c
+++ b/libfxcg/misc/calloc.c
@@ -1,3 +1,4 @@
+#include <fxcg/heap.h>
 #include <stdlib.h>
 
 extern void* memsetZero(void *dest, int n);
@@ -5,7 +6,7 @@ extern void* memsetZero(void *dest, int n);
 void *sys_calloc(int elements, int elementSize){
     int p = elements*elementSize;
     void *tmp;
-    tmp=malloc(p);
+    tmp=sys_malloc(p);
     if (tmp==0)
         return 0;
 


### PR DESCRIPTION
Hello!

After seeing issue #75, I reaslied that I had not fixed calloc when changing the free, malloc, and realloc aliases.
In this PR, I have added a `calloc` alias to `sys_calloc` in the same way as the other aliases .
I have also fixed the sys_calloc function by telling it to use sys_malloc rather than malloc.