### PR TITLE
Add alias to sys_rand and sys_srand

### DIFF
--- a/libfxcg/misc/random.c
+++ b/libfxcg/misc/random.c
@@ -1,4 +1,5 @@
 static unsigned long next = 1;
+
 /* RAND_MAX assumed to be 32767 */
 int sys_rand(void) {
     next = next * 1103515245 + 12345;
@@ -8,3 +9,6 @@ int sys_rand(void) {
 void sys_srand(unsigned seed) {
     next = seed;
 }
+
+__attribute__((weak)) int rand(void) { return sys_rand(); }
+__attribute__((weak)) void srand(unsigned seed) { srand(seed); }


### PR DESCRIPTION
Currently, rand() and srand() are declared in stdlib.h but not actually defined.

This commit adds weak aliases to them from sys_rand and sys_srand, similar to #74.