### PR TITLE
Add ptrdiff_t type to stddef.h

### DIFF
--- a/include/stddef.h
+++ b/include/stddef.h
@@ -21,6 +21,10 @@ typedef unsigned char wchar_t;
 typedef unsigned size_t;
 #endif
 
+#ifndef ptrdiff_t
+typedef int ptrdiff_t;
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR defines ptrdiff_t in `stddef.h`.

According to the man page for ptrdiff_t, it is supposed to be able to store PTRDIFF_MAX, which in `stdint.h` is defined as INT32_MAX, and thus has been typedef-ed to store an int.