### PR TITLE
Add ALPHA+- and CLIP+arrow keycodes

### DIFF
--- a/include/fxcg/keyboard.h
+++ b/include/fxcg/keyboard.h
@@ -155,6 +155,11 @@
 #define KEY_CTRL_RESERVE2   30061
 #define KEY_SHIFT_LEFT      30062
 #define KEY_SHIFT_RIGHT     30063
+#define KEY_ALPHA_MINUS     30070
+#define KEY_CLIP_UP         30041
+#define KEY_CLIP_DOWN       30044
+#define KEY_CLIP_LEFT       30042
+#define KEY_CLIP_RIGHT      30043
 
 #define KEY_PRGM_ACON 10
 #define KEY_PRGM_DOWN 37


### PR DESCRIPTION
Hello!

After some testing I have found that using the CLIP keyboard modifier (setup setting 20, value 2) when pressing the arrow keys yields different keycodes to normally pressing them. These are now included in fxcg/keyboard.h.

I also found that pressing the - (minus) key with upper or lowercase alpha on also yields a different key to normal, which is also now included in fxcg/keyboard.h.