### PR TITLE
Add Enable and DisableGetkeyToMainFunctionReturn

### DIFF
--- a/include/fxcg/keyboard.h
+++ b/include/fxcg/keyboard.h
@@ -225,9 +225,10 @@ int Keyboard_SpyMatrixCode(char*column, char*row);
 void Bkey_SetAllFlags(short flags);
 short Bkey_GetAllFlags( void );
 
-/* whether user can get into Main Menu with GetKey. 1=menu enabled, 0=menu locked.
- * "Set" syscall doesn't exist, must be done through address trickery. */
+/* whether user can get into Main Menu with GetKey. 1=menu enabled, 0=menu locked */
 int GetGetkeyToMainFunctionReturnFlag( void );
+void EnableGetkeyToMainFunctionReturn( void );
+void DisableGetkeyToMainFunctionReturn( void );
 
 #ifdef __cplusplus
 }

--- a/libfxcg/syscalls/DisableGetkeyToMainFunctionReturn.S
+++ b/libfxcg/syscalls/DisableGetkeyToMainFunctionReturn.S
@@ -1,0 +1,3 @@
+#include <asm.h>
+
+SYSCALL(_DisableGetkeyToMainFunctionReturn, 0x1EA7)

--- a/libfxcg/syscalls/EnableGetkeyToMainFunctionReturn.S
+++ b/libfxcg/syscalls/EnableGetkeyToMainFunctionReturn.S
@@ -1,0 +1,3 @@
+#include <asm.h>
+
+SYSCALL(_EnableGetkeyToMainFunctionReturn, 0x1EA6)


### PR DESCRIPTION
Hello!

This PR adds the previously unknown syscalls 0x1ea6 and 0x1ea7, or EnableGetkeyToMainFunctionReturn and DisableGetkeyToMainFunctionReturn.

As their names imply, these syscalls enable or disable the GetkeyToMainFunctionReturnFlag, enabling or disabling returning to the main function during GetKey.

Even though this pointer changes between versions, these syscalls exist and have the same function in all OS versions.