### PR TITLE
Add USB syscalls

### DIFF
--- a/include/fxcg/usb.h
+++ b/include/fxcg/usb.h
@@ -1,0 +1,27 @@
+#ifndef _FXCG_USB_H
+#define _FXCG_USB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int USB_Open(short param_1);
+int USB_IsOpen(void);
+int USB_Close(void);
+
+int USB_Read(unsigned char *out, int sz, short *count);
+int USB_ReadSingle(unsigned char *out);
+int USB_Peek(int idx, unsigned char *out);
+int USB_PollRX(void);
+int USB_ClearRX(void);
+
+int USB_Write(const unsigned char *buf, int count);
+int USB_WriteSingle(unsigned char x);
+int USB_PollTX(void);
+int USB_ClearTX(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/fxcg/usb.h
+++ b/include/fxcg/usb.h
@@ -7,7 +7,7 @@ extern "C" {
 
 int USB_Open(short param_1);
 int USB_IsOpen(void);
-int USB_Close(int mode);
+int USB_Close(void);
 
 int USB_Read(unsigned char *out, int sz, short *count);
 int USB_ReadSingle(unsigned char *out);

--- a/include/fxcg/usb.h
+++ b/include/fxcg/usb.h
@@ -7,7 +7,7 @@ extern "C" {
 
 int USB_Open(short param_1);
 int USB_IsOpen(void);
-int USB_Close(void);
+int USB_Close(int mode);
 
 int USB_Read(unsigned char *out, int sz, short *count);
 int USB_ReadSingle(unsigned char *out);

--- a/libfxcg/syscalls/USB_ClearRX.S
+++ b/libfxcg/syscalls/USB_ClearRX.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_ClearRX, 0x1EE2)
+

--- a/libfxcg/syscalls/USB_ClearTX.S
+++ b/libfxcg/syscalls/USB_ClearTX.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_ClearTX, 0x1EE3)
+

--- a/libfxcg/syscalls/USB_Close.S
+++ b/libfxcg/syscalls/USB_Close.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_Close, 0x1350)
+

--- a/libfxcg/syscalls/USB_IsOpen.S
+++ b/libfxcg/syscalls/USB_IsOpen.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_IsOpen, 0x1ED9)
+

--- a/libfxcg/syscalls/USB_Open.S
+++ b/libfxcg/syscalls/USB_Open.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_Open, 0x134E)
+

--- a/libfxcg/syscalls/USB_Peek.S
+++ b/libfxcg/syscalls/USB_Peek.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_Peek, 0x1EDF)
+

--- a/libfxcg/syscalls/USB_PollRX.S
+++ b/libfxcg/syscalls/USB_PollRX.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_PollRX, 0x1EE0)
+

--- a/libfxcg/syscalls/USB_PollTX.S
+++ b/libfxcg/syscalls/USB_PollTX.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_PollTX, 0x1EE1)
+

--- a/libfxcg/syscalls/USB_Read.S
+++ b/libfxcg/syscalls/USB_Read.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_Read, 0x1EDE)
+

--- a/libfxcg/syscalls/USB_ReadSingle.S
+++ b/libfxcg/syscalls/USB_ReadSingle.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_ReadSingle, 0x1EDD)
+

--- a/libfxcg/syscalls/USB_Write.S
+++ b/libfxcg/syscalls/USB_Write.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_Write, 0x1EDB)
+

--- a/libfxcg/syscalls/USB_WriteSingle.S
+++ b/libfxcg/syscalls/USB_WriteSingle.S
@@ -1,0 +1,4 @@
+#include <asm.h>
+
+SYSCALL(_USB_WriteSingle, 0x1EDA)
+


### PR DESCRIPTION
These are direct equivalents to the serial syscalls, but communicate over USB bulk transfer instead (not protocol 7, just raw data).
 
I found these by decompiling the Comm syscalls in Ghidra, which makes it very obvious that these are direct equivalents, e.g.:
![image](https://user-images.githubusercontent.com/13787163/212494954-3551e017-ca80-427f-9569-d63e874877e7.png)

Not all of them are tested, but I have gotten basic two-way communication working with libusb. The usage on the calculator side looks something like:

```c
USB_Open(0x20);
USB_ClearRX();

USB_Write((unsigned char *) "Hello World!", 13);

// Wait for response
while (USB_PollRX() == 0) {
  // This is close to how the OS's USB functions wait
  OS_InnerWait_ms(25); // Wait 25ms
}

char buf[102];
buf[0] = '-';
buf[1] = '-';
// Receive a message and print it
short count;
USB_Read((unsigned char *) buf + 2, 100, &count);
Bdisp_AllClr_VRAM();
PrintXY(1, 1, buf, 0, COLOR_BLACK);
int key;
GetKey(&key);

USB_Close();
```
This doesn't seem properly close the connection because I can't connect again after, so I still need to work that part out