### PR TITLE
Fix mistake in crt0 (I think)

### DIFF
--- a/libfxcg/misc/crt0.S
+++ b/libfxcg/misc/crt0.S
@@ -49,7 +49,7 @@ bssDone:
    
     mov.l main, r7
     extu.w r14, r5
-    mov.l @r15+, r5
+    mov.l @r15+, r4
     lds.l @r15+, pr
     jmp @r7
     mov.l @r15+, r14        ! Delay slot


### PR DESCRIPTION
r4 gets pushed but then it's popped to r5, overwriting what was just done to restore it from r14, which seems like a bug to me. I'm not sure if anyone actually uses these parameters but it still seems better to have it right