### PR TITLE
Add fabs, fabsf, and fabsl

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -25,6 +25,10 @@ extern "C" {
 #define M_SQRT2 1.41421356237309504880    /* sqrt(2) */
 #define M_SQRT1_2 0.70710678118654752440  /* 1/sqrt(2) */
 
+double fabs(double x);
+float fabsf(float x);
+long double fabsl(long double x);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -6,7 +6,7 @@ CFLAGS=-c -ffunction-sections -fdata-sections -Os -flto -ffat-lto-objects \
 	   -m4a-nofpu -mhitachi -ffreestanding -Wall -Wsystem-headers -g -I../include
 LDFLAGS=-Wl,-static -lfxcg
 ARFLAGS=rsv
-OBJECTS=printf.o setjmp.o stdio.o stdlib.o ctype.o string.o unistd.o time.o
+OBJECTS=printf.o setjmp.o stdio.o stdlib.o ctype.o string.o unistd.o time.o math.o
 LIBRARY=libc.a
 
 all: $(LIBRARY)

--- a/libc/math.c
+++ b/libc/math.c
@@ -1,0 +1,20 @@
+double fabs(double x) {
+    if (x < 0)
+        return -x;
+    else
+        return x;
+}
+
+float fabsf(float x) {
+    if (x < 0)
+        return -x;
+    else
+        return x;
+}
+
+long double fabsl(long double x) {
+    if (x < 0)
+        return -x;
+    else
+        return x;
+}


### PR DESCRIPTION
Hello!

This PR adds `double fabs(double x)`, `float fabsf(float x)`, and `long double fabsl(long double x)` (absolute values of floating-point numbers) to math.h.