### PR TITLE
Modify libc FILE* behaviour for standard streams

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -20,6 +20,10 @@ typedef struct {
     unsigned char unput;
     /* Used only for terminal output (on stdout) */
     unsigned short termx, termy;
+    /* Whether to output to the serial (default for stderr and stdout) */
+    unsigned char out_serial : 1;
+    /* Whether to output to the screen (default for stdout) */
+    unsigned char out_screen : 1;
 } FILE;
 
 extern FILE _impl_stdin, _impl_stdout, _impl_stderr;


### PR DESCRIPTION
This PR addresses issue #30.
The proposed changes in that issue were (as far as I can tell):
- `stderr` and `stdout` outputting to serial and display (already implemented), with `stdout` going to serial and display (new in this PR).
- Adding out_serial and out_screen members to the stdio FILE struct, allowing the user to modify their stdout and stderr implementations and change the output method(s).

Both of these changes are implemented in this PR.