### PR TITLE
Fix no-argument functions marked as variable args

### DIFF
--- a/include/fxcg/app.h
+++ b/include/fxcg/app.h
@@ -14,8 +14,8 @@ void APP_SYSTEM_RESET( void );
 void APP_SYSTEM_VERSION( void );
 void APP_SYSTEM( void );
 void APP_RUNMAT(int, int);
-void APP_MEMORY();
-void App_Optimize();
+void APP_MEMORY( void );
+void App_Optimize( void );
 
 void ResetAllDialog( void );
 unsigned char*GetAppName( unsigned char*name );

--- a/include/fxcg/display.h
+++ b/include/fxcg/display.h
@@ -252,7 +252,7 @@ typedef enum {
     DT_Winsim
 } DeviceType;
 
-inline DeviceType getDeviceType() {
+inline DeviceType getDeviceType(void) {
   #if TARGET_PRIZM
     return (unsigned int)GetVRAMAddress() == 0xAC000000 ? DT_CG50 : DT_CG20;
   #else

--- a/include/fxcg/keyboard.h
+++ b/include/fxcg/keyboard.h
@@ -210,7 +210,7 @@ void Set_FKeys1( unsigned int p1, unsigned int*P2 );
 void PRGM_GetKey_OS( unsigned char*p );
 int GetKey(int*key);
 int GetKeyWait_OS(int*column, int*row, int type_of_waiting, int timeout_period, int menu, unsigned short*keycode );
-int PRGM_GetKey();
+int PRGM_GetKey( void );
 void DisplayMBString(unsigned char *MB_string, int start, int xpos, int x, int y);
 void DisplayMBString2( int select, unsigned char*MB_string, int start, int xpos, int sel_start, int x, int y, int pos_to_clear, int right_margin, int key );
 void EditMBStringCtrl(unsigned char *MB_string, int posmax, int *start, int *xpos, int *key, int x, int y);

--- a/include/fxcg/system.h
+++ b/include/fxcg/system.h
@@ -5,17 +5,17 @@ extern "C" {
 // This adds in syscalls for interfacing with the OS and hardware.
 
 void SetAutoPowerOffTime(int durationInMinutes);
-int GetAutoPowerOffTime(); //returns duration in minutes
+int GetAutoPowerOffTime(void); //returns duration in minutes
 
 void SetBacklightDuration(char durationInHalfMinutes);
-char GetBacklightDuration(); //returns duration in half-minutes
+char GetBacklightDuration(void); //returns duration in half-minutes
 
 void SetBatteryType(int type);
 int GetBatteryType(void);
 
 int GetMainBatteryVoltage(int one); //parameter should be 1
 void PowerOff(int displayLogo);
-void Restart();
+void Restart(void);
 void SpecialMatrixcodeProcessing(int*col, int*row);
 void TestMode(int);
 void*GetStackPtr(void);
@@ -39,7 +39,7 @@ void OS_InnerWait_ms(int);
 void CMT_Delay_100micros(int); //does CMT stand for Composable Memory Transactions? Couldn't find documentation on this
 void CMT_Delay_micros(int); //   nor on this (gbl08ma)
 
-void SetQuitHandler(void (*)()); // sets callback to be run when user exits through the main menu from one app to another. eActivity uses this in the "Save file?" dialog
+void SetQuitHandler(void (*)(void)); // sets callback to be run when user exits through the main menu from one app to another. eActivity uses this in the "Save file?" dialog
 
 void Alpha_SetData( char VarName, void* Src );
 void Alpha_GetData( char VarName, void* Dest );

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -29,7 +29,7 @@ double strtod(const char *s, char **str_end);
 void qsort(void *base, size_t nel, size_t width, int (*compar)(const void *, const void *));
 
 void exit(int status) __attribute__ ((noreturn));
-void abort();
+void abort(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
PR #64 has become outdated, and thus I have created this PR to replace it.
Whilst this is by no means an important change, it makes these definitions clearer.