### PR TITLE
Remove reentrant dynamic memory functions

### DIFF
--- a/libfxcg/misc/callocr.c
+++ b/libfxcg/misc/callocr.c
@@ -1,8 +1,0 @@
-#include <stdlib.h>
-#include <stddef.h>
-
-void *
-_calloc_r (struct _reent *ptr, size_t size, size_t len)
-{
-  return calloc (size, len);
-}

--- a/libfxcg/misc/freer.c
+++ b/libfxcg/misc/freer.c
@@ -1,7 +1,0 @@
-#include <stdlib.h>
-
-void
-_free_r (struct _reent *ptr, void *addr)
-{
-  free (addr);
-}

--- a/libfxcg/misc/mallocr.c
+++ b/libfxcg/misc/mallocr.c
@@ -1,7 +1,0 @@
-#include <stdlib.h>
-
-void *
-_malloc_r (struct _reent *ptr, int size)
-{
-  return malloc (size);
-}

--- a/libfxcg/misc/reallocr.c
+++ b/libfxcg/misc/reallocr.c
@@ -1,7 +1,0 @@
-#include <stdlib.h>
-
-void *
-_realloc_r (struct _reent *ptr, void *old, int newlen)
-{
-  return realloc (old, newlen);
-}


### PR DESCRIPTION
This PR removes the unused _free_r, _calloc_r, _malloc_r, and _realloc_r functions.