### PR TITLE
Don't make srand() recurse on itself

### DIFF
--- a/libfxcg/misc/random.c
+++ b/libfxcg/misc/random.c
@@ -11,4 +11,4 @@ void sys_srand(unsigned seed) {
 }
 
 __attribute__((weak)) int rand(void) { return sys_rand(); }
-__attribute__((weak)) void srand(unsigned seed) { srand(seed); }
+__attribute__((weak)) void srand(unsigned seed) { sys_srand(seed); }


### PR DESCRIPTION
It looks like having srand() call itself rather than sys_srand()
was just an error which nobody ever noticed.