### PR TITLE
Fix typo in linker script

### DIFF
--- a/toolchain/prizm.x
+++ b/toolchain/prizm.x
@@ -22,7 +22,7 @@ SECTIONS
         } > rom
 
         .ilram : {
-                _ilramld = LOADADDR(.data) ;
+                _ilramld = LOADADDR(.ilram) ;
                 _silram = . ;
                 *(.ilram)
                 *(.ilram.*)


### PR DESCRIPTION
_ilramld should be the load address of .ilram, not .data